### PR TITLE
fix: tab visible when inactive

### DIFF
--- a/src/manager/containers/LocalePanel/index.js
+++ b/src/manager/containers/LocalePanel/index.js
@@ -51,6 +51,11 @@ export default function LocalePanel(props) {
     );
   });
 
+
+  if (!props.active) {
+    return null
+  }
+
   return <div style={panelStyle}>{items}</div>;
 }
 


### PR DESCRIPTION
hides the panel when it's not active. Currently if there are multiple addons enabled, switching between them will show linguijs addon on all tabs even when it's not active